### PR TITLE
feat(ui): implements dashboard template

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -76,7 +76,8 @@
         "@typescript-eslint/no-misused-promises": "off",
         "@typescript-eslint/no-floating-promises": "off",
         "jsx-a11y/anchor-is-valid": "off",
-        "no-param-reassign": "off"
+        "no-param-reassign": "off",
+        "arrow-body-style": "off"
       }
     },
     {

--- a/libs/editor/jest.config.ts
+++ b/libs/editor/jest.config.ts
@@ -1,13 +1,13 @@
 export default {
   displayName: 'editor',
   preset: '../../jest.preset.js',
-  globals: {
-    'ts-jest': {
-      tsconfig: '<rootDir>/tsconfig.spec.json',
-    },
-  },
   transform: {
-    '^.+\\.[tj]sx?$': 'ts-jest',
+    '^.+\\.[tj]sx?$': [
+      'ts-jest',
+      {
+        tsconfig: '<rootdir>/tsconfig.spec.json',
+      },
+    ],
   },
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
   coverageDirectory: '../../coverage/libs/editor',

--- a/libs/server/jest.config.ts
+++ b/libs/server/jest.config.ts
@@ -1,13 +1,13 @@
 export default {
   displayName: 'server',
   preset: '../../jest.preset.js',
-  globals: {
-    'ts-jest': {
-      tsconfig: '<rootDir>/tsconfig.spec.json',
-    },
-  },
   transform: {
-    '^.+\\.[tj]sx?$': 'ts-jest',
+    '^.+\\.[tj]sx?$': [
+      'ts-jest',
+      {
+        tsconfig: '<rootdir>/tsconfig.spec.json',
+      },
+    ],
   },
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
   coverageDirectory: '../../coverage/libs/server',

--- a/libs/ui/jest.config.ts
+++ b/libs/ui/jest.config.ts
@@ -1,13 +1,13 @@
 export default {
   displayName: 'ui',
   preset: '../../jest.preset.js',
-  globals: {
-    'ts-jest': {
-      tsconfig: '<rootDir>/tsconfig.spec.json',
-    },
-  },
   transform: {
-    '^.+\\.[tj]sx?$': 'ts-jest',
+    '^.+\\.[tj]sx?$': [
+      'ts-jest',
+      {
+        tsconfig: '<rootdir>/tsconfig.spec.json',
+      },
+    ],
   },
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
   coverageDirectory: '../../coverage/libs/stitches',

--- a/libs/ui/src/pages/Auth/Auth.spec.tsx
+++ b/libs/ui/src/pages/Auth/Auth.spec.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { Auth } from './Auth';
 
@@ -69,7 +69,11 @@ describe('Auth page', () => {
     );
     const email = 'johndoe123@gmail.com';
     const inputElement = screen.getByPlaceholderText('Enter your email');
-    await userEvent.type(inputElement, email);
+
+    // eslint-disable-next-line testing-library/no-unnecessary-act
+    await act(async () => {
+      await userEvent.type(inputElement, email);
+    });
 
     const loginButton = screen.getByText('Let me in!');
 

--- a/libs/ui/src/templates/Dashboard/Dashboard.spec.tsx
+++ b/libs/ui/src/templates/Dashboard/Dashboard.spec.tsx
@@ -1,0 +1,70 @@
+import { act, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Dashboard } from './Dashboard';
+
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: jest.fn().mockImplementation((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: jest.fn(), // Deprecated
+    removeListener: jest.fn(), // Deprecated
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    dispatchEvent: jest.fn(),
+  })),
+});
+
+describe('Dashboard template', () => {
+  it('renders the logo', () => {
+    render(<Dashboard>Dashboard</Dashboard>);
+
+    expect(screen.getByTitle(/brand/i)).toBeInTheDocument();
+  });
+
+  it('renders the children', () => {
+    render(<Dashboard>Dashboard template</Dashboard>);
+
+    expect(screen.getByText(/dashboard template/i)).toBeInTheDocument();
+  });
+
+  it('opens and closes the menu on mobile', async () => {
+    render(<Dashboard>Dashboard</Dashboard>);
+
+    const button = screen.getByRole('button');
+
+    expect(screen.getByTestId('menu-0')).toBeInTheDocument();
+    expect(screen.getByTitle('Open menu')).toBeInTheDocument();
+    expect(screen.queryByTitle('Close menu')).not.toBeInTheDocument();
+
+    // eslint-disable-next-line testing-library/no-unnecessary-act
+    await act(async () => {
+      await userEvent.click(button);
+    });
+
+    expect(screen.getByTestId('menu-auto')).toBeInTheDocument();
+    expect(screen.queryByTitle('Open menu')).not.toBeInTheDocument();
+    expect(screen.getByTitle('Close menu')).toBeInTheDocument();
+  });
+
+  it('renders the menu with auto height on desktop', () => {
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: jest.fn().mockImplementation((query: string) => ({
+        matches: true,
+        media: query,
+        onchange: null,
+        addListener: jest.fn(), // Deprecated
+        removeListener: jest.fn(), // Deprecated
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+        dispatchEvent: jest.fn(),
+      })),
+    });
+
+    render(<Dashboard>Dashboard</Dashboard>);
+
+    expect(screen.getByTestId('menu-auto')).toBeInTheDocument();
+  });
+});

--- a/libs/ui/src/templates/Dashboard/Dashboard.stories.tsx
+++ b/libs/ui/src/templates/Dashboard/Dashboard.stories.tsx
@@ -1,0 +1,20 @@
+import { Meta, Story } from '@storybook/react';
+import { ComponentProps } from 'react';
+import { Dashboard } from './Dashboard';
+
+const args: ComponentProps<typeof Dashboard> = {
+  children: 'Dashboard content',
+};
+
+const config: Meta<typeof args> = {
+  title: 'Templates / Dashboard',
+  component: Dashboard,
+  args,
+};
+
+export default config;
+
+const Template: Story<typeof args> = (props) => <Dashboard {...props} />;
+
+export const Default = Template.bind({});
+Default.storyName = 'Dashboard';

--- a/libs/ui/src/templates/Dashboard/Dashboard.tsx
+++ b/libs/ui/src/templates/Dashboard/Dashboard.tsx
@@ -1,0 +1,57 @@
+import Link from 'next/link';
+import { FC, PropsWithChildren, useState } from 'react';
+import AnimateHeight from 'react-animate-height';
+import { FiMenu, FiX } from 'react-icons/fi';
+import { useMediaQuery } from 'usehooks-ts';
+import { Brand } from '../../atoms/Brand';
+
+export const Dashboard: FC<PropsWithChildren> = ({ children }) => {
+  const [menuOpen, setMenuOpen] = useState(false);
+
+  const isDesktop = useMediaQuery('(min-width: 1024px)');
+
+  // eslint-disable-next-line no-nested-ternary
+  const menuHeight = isDesktop ? 'auto' : menuOpen ? 'auto' : 0;
+
+  return (
+    <main className="flex flex-col min-h-screen gap-3 p-3 lg:p-6 lg:flex-row lg:gap-6">
+      <nav className="flex flex-col w-full p-3 lg:w-72 lg:p-6">
+        <div className="flex items-center justify-between">
+          <Link href="/">
+            <a className="flex items-center gap-3 font-extrabold">
+              <Brand size={36} />
+              Noodle
+            </a>
+          </Link>
+          <button
+            type="button"
+            className="inline-block lg:hidden"
+            onClick={() => setMenuOpen((prev) => !prev)}
+          >
+            {menuOpen ? (
+              <FiX title="Close menu" size={24} />
+            ) : (
+              <FiMenu title="Open menu" size={24} />
+            )}
+          </button>
+        </div>
+        <AnimateHeight
+          data-testid={`menu-${menuHeight}`}
+          duration={150}
+          height={menuHeight}
+        >
+          <ul className="pt-3">
+            <li>
+              <Link href="/modules">
+                <a>Modules</a>
+              </Link>
+            </li>
+          </ul>
+        </AnimateHeight>
+      </nav>
+      <div className="flex-1 p-6 rounded-2xl ring-1 dark:ring-zinc-800 ring-zinc-100">
+        {children}
+      </div>
+    </main>
+  );
+};

--- a/libs/ui/src/templates/Dashboard/index.ts
+++ b/libs/ui/src/templates/Dashboard/index.ts
@@ -1,0 +1,1 @@
+export { Dashboard } from './Dashboard';

--- a/libs/ui/src/templates/Navbar/Navbar.spec.tsx
+++ b/libs/ui/src/templates/Navbar/Navbar.spec.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { Navbar } from './Navbar';
 
@@ -10,7 +10,10 @@ describe('Navigation bar template', () => {
 
     expect(screen.getByTestId('pages-links')).not.toHaveClass('absolute');
 
-    await userEvent.click(button);
+    // eslint-disable-next-line testing-library/no-unnecessary-act
+    await act(async () => {
+      await userEvent.click(button);
+    });
 
     expect(screen.getByTestId('pages-links')).toHaveClass('absolute');
   });
@@ -22,7 +25,10 @@ describe('Navigation bar template', () => {
 
     const button = screen.getByRole('button');
 
-    await userEvent.click(button);
+    // eslint-disable-next-line testing-library/no-unnecessary-act
+    await act(async () => {
+      await userEvent.click(button);
+    });
 
     expect(screen.getByTitle(/close-menu/i)).toBeInTheDocument();
   });

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "next-seo": "^5.5.0",
     "nodemailer": "^6.7.8",
     "react": "^18.2.0",
+    "react-animate-height": "^3.0.4",
     "react-dnd": "16.0.1",
     "react-dnd-html5-backend": "16.0.1",
     "react-dom": "^18.2.0",
@@ -61,6 +62,7 @@
     "superjson": "^1.10.0",
     "tailwind-merge": "^1.6.0",
     "tslib": "^2.4.0",
+    "usehooks-ts": "^2.7.1",
     "zod": "^3.19.1"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -109,6 +109,7 @@ specifiers:
   prettier-plugin-organize-imports: ^3.1.1
   prisma: ^4.3.1
   react: ^18.2.0
+  react-animate-height: ^3.0.4
   react-dnd: 16.0.1
   react-dnd-html5-backend: 16.0.1
   react-dom: ^18.2.0
@@ -133,6 +134,7 @@ specifiers:
   tslib: ^2.4.0
   typescript: ^4.8.3
   url-loader: ^4.1.1
+  usehooks-ts: ^2.7.1
   zod: ^3.19.1
 
 dependencies:
@@ -171,6 +173,7 @@ dependencies:
   next-seo: 5.5.0_c3hne4hwj64hb7tofigd3bvkji
   nodemailer: 6.7.8
   react: 18.2.0
+  react-animate-height: 3.0.4_biqbaboplfbrettd7655fr4n2y
   react-dnd: 16.0.1_qwravoh5geot5nrl3riagcuhi4
   react-dnd-html5-backend: 16.0.1
   react-dom: 18.2.0_react@18.2.0
@@ -184,6 +187,7 @@ dependencies:
   superjson: 1.10.0
   tailwind-merge: 1.6.0
   tslib: 2.4.0
+  usehooks-ts: 2.7.1_biqbaboplfbrettd7655fr4n2y
   zod: 3.19.1
 
 devDependencies:
@@ -9200,6 +9204,10 @@ packages:
       typescript: 4.8.3
     dev: false
 
+  /classnames/2.3.2:
+    resolution: {integrity: sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw==}
+    dev: false
+
   /clean-css/4.2.4:
     resolution: {integrity: sha512-EJUDT7nDVFDvaQgAo2G/PJvxmp1o/c6iXLbswsBbUFXi1Nr+AjA2cKmfbKDMjMvzEe75g3P6JkaDDAKk96A85A==}
     engines: {node: '>= 4.0'}
@@ -17433,6 +17441,18 @@ packages:
       react-dom: 18.2.0_react@18.2.0
     dev: false
 
+  /react-animate-height/3.0.4_biqbaboplfbrettd7655fr4n2y:
+    resolution: {integrity: sha512-k+mBS8yCzpFp+7BdrHsL5bXd6CO/2bYO2SvRGKfxK+Ss3nzplAJLlgnd6Zhcxe/avdpy/CgcziicFj7pIHgG5g==}
+    engines: {node: '>= 12.0.0'}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+    dependencies:
+      classnames: 2.3.2
+      react: 18.2.0
+      react-dom: 18.2.0_react@18.2.0
+    dev: false
+
   /react-dnd-html5-backend/16.0.1:
     resolution: {integrity: sha512-Wu3dw5aDJmOGw8WjH1I1/yTH+vlXEL4vmjk5p+MHxP8HuHJS1lAGeIdG/hze1AvNeXWo/JgULV87LyQOr+r5jw==}
     dependencies:
@@ -20300,6 +20320,17 @@ packages:
     resolution: {integrity: sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==}
     engines: {node: '>=0.10.0'}
     dev: true
+
+  /usehooks-ts/2.7.1_biqbaboplfbrettd7655fr4n2y:
+    resolution: {integrity: sha512-7WgP5ELpmJ/5rZ4P+YnfhLXdiGf1Xpy4iLnjcifBGmwBWXBBa9FZRRHNOiJJw1NKIAU9LOaKaps4G3KXLPhZ6w==}
+    engines: {node: '>=16.15.0', npm: '>=8'}
+    peerDependencies:
+      react: ^16.8.0  || ^17.0.0 || ^18.0.0
+      react-dom: ^16.8.0  || ^17.0.0 || ^18.0.0
+    dependencies:
+      react: 18.2.0
+      react-dom: 18.2.0_react@18.2.0
+    dev: false
 
   /util-deprecate/1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}


### PR DESCRIPTION
Closes #36 

This PR implements the skeleton shape of the dashboard layout, it is mobile responsive with a menu that pops up once the hamburger icon is pressed.

<img width="1259" alt="CleanShot 2022-09-23 at 02 34 51@2x" src="https://user-images.githubusercontent.com/20271968/191877692-1ebca83d-d4e8-4c64-b801-faccc4ed47ed.png">
<img width="377" alt="CleanShot 2022-09-23 at 02 35 11@2x" src="https://user-images.githubusercontent.com/20271968/191877714-faa30271-718a-4323-bf9c-fbb2761e8be6.png">
<img width="381" alt="CleanShot 2022-09-23 at 02 35 31@2x" src="https://user-images.githubusercontent.com/20271968/191877741-29563d13-ca94-4500-b903-2ab56ed55e7c.png">
