### PR TITLE
Remove default title in issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,7 +1,7 @@
 ---
 name: Bug report
 about: Create a report to help us improve
-title: "[BUG]"
+title: ""
 labels: bug
 assignees: ""
 ---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,7 +1,7 @@
 ---
 name: Feature request
 about: Suggest an idea for this project
-title: "[FEAT]"
+title: ""
 labels: enhancement
 assignees: ""
 ---


### PR DESCRIPTION
The default title prefixes the issue title with `[BUG]` or `[FEAT]`. If there is a reason to do this, feel free to just close the PR, however I see no reason that this should be here considering we have labels for filtering. The `bug` and `enhancement` labels are automatically applied when using the issue templates.

I did not ask a team member about this, considering that would take more time than making the PR itself.