### PR TITLE
Update github repository URL

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,7 +43,7 @@ Our preferred way of providing the opportunity for people to contribute to Noodl
 
 - You see an area of improvement in the code base, this could be a fix, feature, refactoring...etc
 
-- Create an [issue](https://github.com/ixahmedxi/noodle/issues) on our Github repository.
+- Create an [issue](https://github.com/noodle-run/noodle/issues) on our Github repository.
 
 - Wait until a team member discusses the issue with you, and if both parties are in agreement, you can assign yourself to the issue.
 
@@ -106,7 +106,7 @@ There are a lot of other technologies being used in this project, however these 
 
 ### Cloning the repo
 
-To clone the repo, you firstly need to [fork](https://github.com/ixahmedxi/noodle/fork) it, and then clone your copy of noodle locally.
+To clone the repo, you firstly need to [fork](https://github.com/noodle-run/noodle/fork) it, and then clone your copy of noodle locally.
 
 ```bash
 git clone https://github.com/<your-gh-username>/noodle.git

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <div align="center">
-  <img src="https://github.com/ixahmedxi/noodle/blob/main/public/logo.png?raw=true" alt="Noodle logo" width="75">  
+  <img src="https://github.com/noodle-run/noodle/blob/main/public/logo.png?raw=true" alt="Noodle logo" width="75">  
   <h1>Noodle <br> Rethinking Student Productivity</h1>
   <br>
 </div>
@@ -14,7 +14,7 @@
 >
 > Follow me on twitter [@ixahmedxii](https://twitter.com/ixahmedxii) for updates.
 
-![Noodle Preview](https://github.com/ixahmedxi/noodle/blob/main/public/preview.png?raw=true)
+![Noodle Preview](https://github.com/noodle-run/noodle/blob/main/public/preview.png?raw=true)
 
 <p align="center" style="color:dodgerblue;"><strong>⚠️ This is a UI design mockup of what the platform will look like, it is not the current state of the project.</strong></p>
 
@@ -40,5 +40,5 @@ As an open-source platform, Noodle strives to cultivate a community of students 
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=ixahmedxi/noodle#gh-light-mode-only)](https://star-history.com/#ixahmedxi/noodle#gh-light-mode-only)
-[![Star History Chart](https://api.star-history.com/svg?repos=ixahmedxi/noodle&theme=dark#gh-dark-mode-only)](https://star-history.com/#ixahmedxi/noodle#gh-dark-mode-only)
+[![Star History Chart](https://api.star-history.com/svg?repos=noodle-run/noodle#gh-light-mode-only)](https://star-history.com/#noodle-run/noodle#gh-light-mode-only)
+[![Star History Chart](https://api.star-history.com/svg?repos=noodle-run/noodle&theme=dark#gh-dark-mode-only)](https://star-history.com/#noodle-run/noodle#gh-dark-mode-only)

--- a/src/app/config.tsx
+++ b/src/app/config.tsx
@@ -16,7 +16,7 @@ export const siteConfig = {
   description:
     "Noodle is an open-source platform that combines various productivity tools into one, such as note taking and task management, providing insightful automations to enhance student productivity.",
 
-  github: "https://github.com/ixahmedxi/noodle",
+  github: "https://github.com/noodle-run/noodle",
   twitter: "https://twitter.com/ixahmedxii",
   discord: "https://discord.gg/SERySfj8Eg",
   instagram: "https://instagram.com/noodle.run",


### PR DESCRIPTION
Had this laying for a few days, updates repository URL to the new noodle-run organisation.

Fixes #336 