### PR TITLE
feat: caches weather with redis & info tooltip

### DIFF
--- a/src/app/(dashboard)/_components/waitlist-form.tsx
+++ b/src/app/(dashboard)/_components/waitlist-form.tsx
@@ -27,13 +27,10 @@ export const WaitListInvitationForm = ({
 
   const { mutateAsync, isLoading } =
     trpc.waitlist.sendUserInvitation.useMutation({
-      async onSuccess(data) {
-        console.log(data);
+      async onSuccess() {
         await utils.waitlist.invalidate();
       },
     });
-
-  console.log(form.formState.errors);
 
   const onSubmit = async (values: z.infer<typeof formSchema>) => {
     try {

--- a/src/app/(dashboard)/app/_components/weather.tsx
+++ b/src/app/(dashboard)/app/_components/weather.tsx
@@ -2,10 +2,11 @@
 
 import { type FC } from "react";
 
+import { Icon } from "@/components/icon";
 import { useCoords } from "@/hooks/useCoords";
 import { trpc } from "@/trpc/client";
 import { getFormattedWeatherDescription } from "@/utils/getFormattedWeatherDescription";
-import { Skeleton } from "@nextui-org/react";
+import { Skeleton, Tooltip } from "@nextui-org/react";
 
 export const WeatherData: FC = () => {
   const coords = useCoords();
@@ -39,11 +40,31 @@ export const WeatherData: FC = () => {
   if (!weatherData) return null;
 
   return (
-    <span className="text-tiny text-default-500">
-      You can expect a 👆 high of {weatherData.temp_max.toFixed()}º and a 👇 low
-      of {weatherData.temp_min.toFixed()}º
-      {getFormattedWeatherDescription(weatherData.summary)} for today&apos;s
-      weather.
-    </span>
+    <Tooltip
+      color="default"
+      showArrow
+      classNames={{
+        content: "border dark:border-default-100 border-default-200",
+      }}
+      content={
+        <div className="max-w-[30ch] px-1 py-2">
+          <span className="flex items-center gap-3 pb-2">
+            <Icon name="BadgeInfo" size={16} /> Info
+          </span>
+          <span className="text-tiny leading-5 text-default-500">
+            The weather conditions are until the end of the day, so the high and
+            low temps are until midnight.
+          </span>
+        </div>
+      }
+      placement="left-start"
+      delay={1000}
+    >
+      <button className="cursor-default text-left text-tiny leading-5 text-default-500">
+        You can expect a 👆 high of {weatherData.temp_max.toFixed()}º and a 👇
+        low of {weatherData.temp_min.toFixed()}º{" "}
+        {getFormattedWeatherDescription(weatherData.summary)}.
+      </button>
+    </Tooltip>
   );
 };

--- a/src/server/api/routers/waitlist.ts
+++ b/src/server/api/routers/waitlist.ts
@@ -47,8 +47,6 @@ export const waitlistRouter = createTRPCRouter({
     .mutation(async ({ input, ctx }) => {
       const { invitationId } = input;
 
-      console.log("invitationId", invitationId);
-
       const invitation = await ctx.db
         .select()
         .from(waitlist)

--- a/src/server/api/routers/weather.ts
+++ b/src/server/api/routers/weather.ts
@@ -1,31 +1,135 @@
 import { TRPCError } from "@trpc/server";
-import fetch from "node-fetch";
 import { z } from "zod";
 import { createTRPCRouter, protectedProcedure } from "../trpc";
 
-type RawWeatherData = {
-  properties: {
-    timeseries: {
-      data: {
-        next_12_hours: {
-          summary: {
-            symbol_code: string;
-          };
-        };
-        instant: {
-          details: {
-            air_temperature: number;
-          };
-        };
-      };
-    }[];
-  };
-};
+function getCurrentDate(): string {
+  const currentDate = new Date();
+  const year = currentDate.getFullYear();
+  const month = (currentDate.getMonth() + 1).toString().padStart(2, "0");
+  const day = currentDate.getDate().toString().padStart(2, "0");
 
-type WeatherData = {
-  temp_max: number;
-  temp_min: number;
-  summary: string;
+  return `${year}-${month}-${day}`;
+}
+
+const rawWeatherDataSchema = z.object({
+  type: z.literal("Feature"),
+  geometry: z.object({
+    type: z.literal("Point"),
+    coordinates: z.tuple([z.number(), z.number(), z.number()]),
+  }),
+  properties: z.object({
+    meta: z.object({
+      updated_at: z.string(),
+      units: z.object({
+        air_pressure_at_sea_level: z.string(),
+        air_temperature: z.string(),
+        cloud_area_fraction: z.string(),
+        precipitation_amount: z.string(),
+        relative_humidity: z.string(),
+        wind_from_direction: z.string(),
+        wind_speed: z.string(),
+      }),
+    }),
+    timeseries: z.array(
+      z.object({
+        time: z.string(),
+        data: z.object({
+          next_12_hours: z
+            .object({
+              summary: z.object({
+                symbol_code: z.string(),
+              }),
+            })
+            .optional(),
+          next_6_hours: z
+            .object({
+              summary: z.object({
+                symbol_code: z.string(),
+              }),
+            })
+            .optional(),
+          next_1_hours: z
+            .object({
+              summary: z.object({
+                symbol_code: z.string(),
+              }),
+            })
+            .optional(),
+          instant: z.object({
+            details: z.object({
+              air_temperature: z.number(),
+            }),
+          }),
+        }),
+      }),
+    ),
+  }),
+});
+
+const weatherDataSchema = z.object({
+  temp_max: z.number(),
+  temp_min: z.number(),
+  summary: z.string().optional(),
+});
+
+const getCurrentWeatherData = async ({
+  latitude,
+  longitude,
+}: {
+  latitude: number;
+  longitude: number;
+}) => {
+  const date = getCurrentDate();
+  const request = `https://api.met.no/weatherapi/locationforecast/2.0/compact?lat=${latitude}&lon=${longitude}`;
+  const response = await fetch(request, {
+    headers: {
+      "User-Agent": `noodle.run (https://github.com/noodle-run/noodle)`,
+    },
+  });
+
+  const rawWeatherData = await rawWeatherDataSchema
+    .parseAsync(await response.json())
+    .catch(() => {
+      throw new TRPCError({
+        code: "INTERNAL_SERVER_ERROR",
+        message: "Failed to parse weather data",
+      });
+    });
+
+  const timeserieslist = rawWeatherData.properties.timeseries.filter((one) =>
+    one.time.includes(date),
+  );
+
+  const temperatures = [];
+
+  for (const timeseries of timeserieslist) {
+    temperatures.push(timeseries.data.instant.details.air_temperature);
+  }
+
+  let summary: string | undefined;
+
+  if (timeserieslist[0]?.data.next_12_hours) {
+    summary = timeserieslist[0].data.next_12_hours.summary.symbol_code;
+  } else if (timeserieslist[0]?.data.next_6_hours) {
+    summary = timeserieslist[0].data.next_6_hours.summary.symbol_code;
+  } else {
+    summary = timeserieslist[0]?.data.next_1_hours?.summary.symbol_code;
+  }
+
+  const weatherData = {
+    summary,
+    temp_max: Math.max(...temperatures),
+    temp_min: Math.min(...temperatures),
+  };
+
+  const data = await weatherDataSchema.parseAsync(weatherData).catch(() => {
+    throw new TRPCError({
+      code: "INTERNAL_SERVER_ERROR",
+      message: "Failed to parse weather data",
+    });
+  });
+
+  return data;
 };
 
 export const weatherRouter = createTRPCRouter({
@@ -36,49 +140,46 @@ export const weatherRouter = createTRPCRouter({
         longitude: z.number(),
       }),
     )
-    .query(async ({ input }) => {
-      const { latitude, longitude } = input;
+    .output(weatherDataSchema)
+    .query(async ({ input, ctx }) => {
+      const date = getCurrentDate();
+      if (typeof ctx.redis !== "undefined" && typeof ctx.redis !== "string") {
+        const cachedWeatherData = await ctx.redis.get(
+          `weather:${date}:${ctx.auth.userId}`,
+        );
 
-      const response = await fetch(
-        `https://api.met.no/weatherapi/locationforecast/2.0/compact?lat=${latitude}&lon=${longitude}`,
-        {
-          headers: {
-            "User-Agent": `noodle.run (https://github.com/noodle-run/noodle)`,
-          },
-        },
-      );
+        if (!cachedWeatherData) {
+          const weatherData = await getCurrentWeatherData(input);
 
-      if (!response.ok) {
-        throw new TRPCError({
-          code: "INTERNAL_SERVER_ERROR",
-          message: "Failed to fetch weather data",
-        });
+          const now = new Date();
+          const midnight = new Date(
+            now.getFullYear(),
+            now.getMonth(),
+            now.getDate() + 1,
+          );
+          const secondsUntilMidnight = Math.round(
+            (midnight.getTime() - now.getTime()) / 1000,
+          );
+
+          await ctx.redis.set(
+            `weather:${date}:${ctx.auth.userId}`,
+            JSON.stringify(weatherData),
+            { ex: secondsUntilMidnight },
+          );
+
+          return weatherData;
+        }
+
+        return weatherDataSchema
+          .parseAsync(cachedWeatherData)
+          .then((data) => {
+            return data;
+          })
+          .catch(() => {
+            return getCurrentWeatherData(input);
+          });
       }
 
-      const rawWeatherData: RawWeatherData =
-        (await response.json()) as RawWeatherData;
-
-      if (rawWeatherData.properties.timeseries.length < 12) {
-        throw new TRPCError({
-          code: "INTERNAL_SERVER_ERROR",
-          message: "Partial weather data",
-        });
-      }
-
-      const temperatures = [];
-
-      for (const timeseries of rawWeatherData.properties.timeseries) {
-        temperatures.push(timeseries.data.instant.details.air_temperature);
-      }
-
-      const weatherData: WeatherData = {
-        summary:
-          rawWeatherData.properties.timeseries[0]!.data.next_12_hours.summary
-            .symbol_code,
-        temp_max: Math.max(...temperatures),
-        temp_min: Math.min(...temperatures),
-      };
-
-      return weatherData;
+      return getCurrentWeatherData(input);
     }),
 });

--- a/src/server/api/trpc.ts
+++ b/src/server/api/trpc.ts
@@ -1,6 +1,8 @@
 import { db } from "@/db";
+import { env } from "@/env.mjs";
 import { getAuth } from "@clerk/nextjs/server";
 import { TRPCError, initTRPC } from "@trpc/server";
+import { Redis } from "@upstash/redis";
 import { type NextRequest } from "next/server";
 import superjson from "superjson";
 import { ZodError } from "zod";
@@ -10,9 +12,12 @@ type CreateContextOptions = {
 };
 
 const createInnerTRPCContext = ({ auth }: CreateContextOptions) => {
+  const redis = env.UPSTASH_REDIS_REST_URL && Redis.fromEnv();
+
   return {
     auth,
     db,
+    redis,
   };
 };
 


### PR DESCRIPTION
Closes #355 

This PR aims to do the following:

- Caches the user's weather information until midnight of the current day using Redis, this will make it so that every user only sends the weather api a request every 24 hours.
- Implements a tooltip that gives the user more insights about the weather data they are seeing and how it is calculated.
- Removed console logs from the code in some places.
- Improves the Logic for getting the weather data in terms of:
  - more type-safe operations, parse with zod when we can
  - more accurate way of getting low temperature