### PR TITLE
feat: add security.txt file

### DIFF
--- a/public/.well-known/security.txt
+++ b/public/.well-known/security.txt
@@ -1,0 +1,6 @@
+Contact: https://github.com/noodle-run/noodle/security/advisories/new
+Expires: 2025-12-31T23:00:00.000Z
+Acknowledgments: https://github.com/noodle-run/noodle/security
+Preferred-Languages: en
+Canonical: https://noodle.run/.well-known/security.txt
+Policy: https://github.com/noodle-run/noodle/blob/main/SECURITY.md


### PR DESCRIPTION
This file is used by security researchers for knowing where to report security issues. More information is available on [securitytxt.org](https://securitytxt.org/). Expiry is set to 2026, can increase if wanted.